### PR TITLE
Cleaned up Dockerfile, updated to version 5.5.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.gitignore
+CODEOWNERS
+Jenkinsfile
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.5.2
 
-FROM elasticsearch:5.4.2
+ADD elasticsearch.yml /usr/share/elasticsearch/config/
+USER root
+RUN sed -i '/exclude=java-1.8.0-openjdk*/d' /etc/yum.conf  && \
+    yum install -y java-1.8.0-openjdk-headless nss-sysinit nss nss-tools && \
+    yum remove -y wget && \
+    chown elasticsearch:elasticsearch config/elasticsearch.yml
 
-RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.4.2
-
-ADD elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
+USER elasticsearch


### PR DESCRIPTION
Fixes: https://github.com/samsung-cnct/container-elasticsearch/issues/4
Related to: https://github.com/samsung-cnct/issues/issues/68

**What this PR does / why we need it**:
Reduced total image security vulnerabilities from 118 to 0
Reduced "critical" level vulnerabilities from 1 to 0
Reduced “high” level vulnerabilities from 77 to 0
Added .dockerignore file


Line 18 & 19 address a "critical" level vulnerability in the java package (as well as several other "high" level vulnerabilities in the other packages). Elasticsearch had set a restriction on what CentOS java packages could be made available, so line 18 removes that restriction so we can access the java package with the patch. 