### PR TITLE
decreased image security vulnerabilities by switching to the image us…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,76 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM elasticsearch:5.5.2
+FROM quay.io/pires/docker-jre:8u131_r2
 
-ENV NETWORK_HOST=_site_
+# Export HTTP & Transport
+EXPOSE 9200 9300
 
+ENV ES_VERSION 5.5.2
+
+ENV DOWNLOAD_URL "https://artifacts.elastic.co/downloads/elasticsearch"
+ENV ES_TARBAL "${DOWNLOAD_URL}/elasticsearch-${ES_VERSION}.tar.gz"
+ENV ES_TARBALL_ASC "${DOWNLOAD_URL}/elasticsearch-${ES_VERSION}.tar.gz.asc"
+ENV GPG_KEY "46095ACC8548582C1A2699A9D27D666CD88E42B4"
+
+# Install Elasticsearch.
+RUN apk add --no-cache --update bash ca-certificates su-exec util-linux curl
+RUN apk add --no-cache -t .build-deps gnupg openssl \
+  && cd /tmp \
+  && echo "===> Install Elasticsearch..." \
+  && curl -o elasticsearch.tar.gz -Lskj "$ES_TARBAL"; \
+  if [ "$ES_TARBALL_ASC" ]; then \
+    curl -o elasticsearch.tar.gz.asc -Lskj "$ES_TARBALL_ASC"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY"; \
+    gpg --batch --verify elasticsearch.tar.gz.asc elasticsearch.tar.gz; \
+    rm -r "$GNUPGHOME" elasticsearch.tar.gz.asc; \
+  fi; \
+  tar -xf elasticsearch.tar.gz \
+  && ls -lah \
+  && mv elasticsearch-$ES_VERSION /elasticsearch \
+  && adduser -DH -s /sbin/nologin elasticsearch \
+  && echo "===> Creating Elasticsearch Paths..." \
+  && for path in \
+    /elasticsearch/config \
+    /elasticsearch/config/scripts \
+    /elasticsearch/plugins \
+  ; do \
+  mkdir -p "$path"; \
+  chown -R elasticsearch:elasticsearch "$path"; \
+  done \
+  && rm -rf /tmp/* \
+  && apk del --purge .build-deps
+
+ENV PATH /elasticsearch/bin:$PATH
+
+WORKDIR /elasticsearch
 RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.5.2
 
-ADD elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
+# Copy configuration
+COPY config /elasticsearch/config
+
+# Copy run script
+COPY run.sh /
+
+# Set environment variables defaults
+ENV ES_JAVA_OPTS "-Xms512m -Xmx512m"
+ENV CLUSTER_NAME elasticsearch-default
+ENV NODE_MASTER true
+ENV NODE_DATA true
+ENV NODE_INGEST true
+ENV HTTP_ENABLE true
+ENV NETWORK_HOST _site_
+ENV HTTP_CORS_ENABLE true
+ENV HTTP_CORS_ALLOW_ORIGIN *
+ENV NUMBER_OF_MASTERS 1
+ENV MAX_LOCAL_STORAGE_NODES 1
+ENV SHARD_ALLOCATION_AWARENESS ""
+ENV SHARD_ALLOCATION_AWARENESS_ATTR ""
+ENV MEMORY_LOCK true
+
+# Volume for Elasticsearch data
+VOLUME ["/usr/share/elasticsearch"]
+
+
+CMD ["/run.sh"]

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,0 +1,30 @@
+cluster.name: ${CLUSTER_NAME}
+network.host: ${NETWORK_HOST}
+
+node:
+  master: ${NODE_MASTER}
+  name: ${NODE_NAME}
+  data: ${NODE_DATA}
+  ingest: false
+
+path:
+  data: /usr/share/elasticsearch/data
+  logs: /usr/share/elasticsearch/logs
+
+bootstrap:
+  memory_lock: ${MEMORY_LOCK}
+
+cloud:
+  kubernetes:
+    service: ${SERVICE}
+    namespace: ${KUBERNETES_NAMESPACE}
+
+discovery:
+  zen:
+    hosts_provider: kubernetes
+    minimum_master_nodes: 2
+
+gateway:
+  #recover_after_nodes: 70-80% of running nodes
+  #expected_nodes: total number of nodes
+  recover_after_time: 5m

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -14,17 +14,19 @@ path:
 bootstrap:
   memory_lock: ${MEMORY_LOCK}
 
-cloud:
-  kubernetes:
-    service: ${SERVICE}
-    namespace: ${KUBERNETES_NAMESPACE}
-
-discovery:
-  zen:
-    hosts_provider: kubernetes
-    minimum_master_nodes: 2
-
 gateway:
   #recover_after_nodes: 70-80% of running nodes
   #expected_nodes: total number of nodes
   recover_after_time: 5m
+
+http:
+  enabled: ${HTTP_ENABLE}
+  compression: true
+  cors:
+    enabled: ${HTTP_CORS_ENABLE}
+    allow-origin: ${HTTP_CORS_ALLOW_ORIGIN}
+
+discovery:
+  zen:
+    ping.unicast.hosts: ${DISCOVERY_SERVICE}
+    minimum_master_nodes: 2

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -1,0 +1,109 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+# Commented out since these are supplied as env vars in the command-line
+# for the service.
+
+#-Xms2g
+#-Xmx2g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# disable calls to System#gc
+-XX:+DisableExplicitGC
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM (remove on 32-bit client JVMs)
+-server
+
+# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to keep Netty from being unsafe
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true

--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+BASE=/elasticsearch
+
+# allow for memlock
+ulimit -l unlimited
+
+# Set a random node name if not set.
+if [ -z "${NODE_NAME}" ]; then
+	NODE_NAME=$(uuidgen)
+fi
+export NODE_NAME=${NODE_NAME}
+
+# Prevent "Text file busy" errors
+sync
+
+if [ ! -z "${ES_PLUGINS_INSTALL}" ]; then
+   OLDIFS=$IFS
+   IFS=','
+   for plugin in ${ES_PLUGINS_INSTALL}; do
+      if ! $BASE/bin/elasticsearch-plugin list | grep -qs ${plugin}; then
+         yes | $BASE/bin/elasticsearch-plugin install --batch ${plugin}
+      fi
+   done
+   IFS=$OLDIFS
+fi
+
+if [ ! -z "${SHARD_ALLOCATION_AWARENESS_ATTR}" ]; then
+    # this will map to a file like  /etc/hostname => /dockerhostname so reading that file will get the
+    #  container hostname
+    if [ "$NODE_DATA" == "true" ]; then
+        ES_SHARD_ATTR=`cat ${SHARD_ALLOCATION_AWARENESS_ATTR}`
+        NODE_NAME="${ES_SHARD_ATTR}-${NODE_NAME}"
+        echo "node.attr.${SHARD_ALLOCATION_AWARENESS}: ${ES_SHARD_ATTR}" >> $BASE/config/elasticsearch.yml
+    fi
+    if [ "$NODE_MASTER" == "true" ]; then
+        echo "cluster.routing.allocation.awareness.attributes: ${SHARD_ALLOCATION_AWARENESS}" >> $BASE/config/elasticsearch.yml
+    fi
+fi
+
+# run
+chown -R elasticsearch:elasticsearch $BASE
+chown -R elasticsearch:elasticsearch /usr/share/elasticsearch
+su-exec elasticsearch $BASE/bin/elasticsearch


### PR DESCRIPTION
…ed in the official k8s es deployment, with a few tweaks to work with our deployment.

**What this PR does / why we need it**:
Reduces HIGH image vulnerabilities from 10 to 0
Reduces MED vulnerabilities from 52 to 1
Reduces TOTAL vulnerabilities from 129 to 2
Reduces image SIZE from 252.9 MB to 97.0 MB

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: related to https://github.com/samsung-cnct/issues/issues/68

**Special notes for your reviewer**:
The new "official" elasticsearch docker image is no longer built with a sole Dockerfile, instead the Dockerfile is dynamically built with xpack: https://github.com/elastic/elasticsearch-docker - this is a simplified approach used by the Kubernetes community specifically for running elasticsearch in K8s. 