### PR TITLE
Disable Swapping - `bootstrap.memory_lock`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,11 @@ ENV NETWORK_HOST=_site_
 RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.5.2
 
 ADD elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
+
+#RUN echo "MAX_LOCKED_MEMORY=unlimited" >> /etc/default/elasticsearch
+
+ADD limits.conf /etc/security/limits.conf
+
+COPY custom-entrypoint.sh /custom-entrypoint.sh
+
+ENTRYPOINT ["/custom-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5
 
 ADD elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
 
-#RUN echo "MAX_LOCKED_MEMORY=unlimited" >> /etc/default/elasticsearch
-
 ADD limits.conf /etc/security/limits.conf
 
 COPY custom-entrypoint.sh /custom-entrypoint.sh

--- a/custom-entrypoint.sh
+++ b/custom-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "MAX_LOCKED_MEMORY=unlimited" >> /etc/default/elasticsearch
+echo '1: Before ulimit'
+ulimit -l
+ulimit -l unlimited
+echo '2. After ulimit'
+ulimit -l
+
+exec gosu elasticsearch /usr/share/elasticsearch/bin/elasticsearch

--- a/custom-entrypoint.sh
+++ b/custom-entrypoint.sh
@@ -3,6 +3,7 @@
 set -e
 
 echo "MAX_LOCKED_MEMORY=unlimited" >> /etc/default/elasticsearch
+# https://github.com/kubernetes/kubernetes/issues/3595#issuecomment-288451522
 echo '1: Before ulimit'
 ulimit -l
 ulimit -l unlimited

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -23,3 +23,5 @@ discovery.zen.minimum_master_nodes: 2
 path:
   data: /usr/share/elasticsearch/data
   logs: /usr/share/elasticsearch/logs
+
+bootstrap.memory_lock: true

--- a/limits.conf
+++ b/limits.conf
@@ -1,0 +1,62 @@
+# /etc/security/limits.conf
+#
+#Each line describes a limit for a user in the form:
+#
+#<domain>        <type>  <item>  <value>
+#
+#Where:
+#<domain> can be:
+#        - a user name
+#        - a group name, with @group syntax
+#        - the wildcard *, for default entry
+#        - the wildcard %, can be also used with %group syntax,
+#                 for maxlogin limit
+#        - NOTE: group and wildcard limits are not applied to root.
+#          To apply a limit to the root user, <domain> must be
+#          the literal username root.
+#
+#<type> can have the two values:
+#        - "soft" for enforcing the soft limits
+#        - "hard" for enforcing hard limits
+#
+#<item> can be one of the following:
+#        - core - limits the core file size (KB)
+#        - data - max data size (KB)
+#        - fsize - maximum filesize (KB)
+#        - memlock - max locked-in-memory address space (KB)
+#        - nofile - max number of open files
+#        - rss - max resident set size (KB)
+#        - stack - max stack size (KB)
+#        - cpu - max CPU time (MIN)
+#        - nproc - max number of processes
+#        - as - address space limit (KB)
+#        - maxlogins - max number of logins for this user
+#        - maxsyslogins - max number of logins on the system
+#        - priority - the priority to run user process with
+#        - locks - max number of file locks the user can hold
+#        - sigpending - max number of pending signals
+#        - msgqueue - max memory used by POSIX message queues (bytes)
+#        - nice - max nice priority allowed to raise to values: [-20, 19]
+#        - rtprio - max realtime priority
+#        - chroot - change root to directory (Debian-specific)
+#
+#<domain>      <type>  <item>         <value>
+#
+
+#*               soft    core            0
+#root            hard    core            100000
+#*               hard    rss             10000
+#@student        hard    nproc           20
+#@faculty        soft    nproc           20
+#@faculty        hard    nproc           50
+#ftp             hard    nproc           0
+#ftp             -       chroot          /ftp
+#@student        -       maxlogins       4
+
+elasticsearch    -       nofile          65536
+elasticsearch    soft    memlock         unlimited
+elasticsearch    hard    memlock         unlimited
+elasticsearch    soft    nproc           16385
+elasticsearch    hard    nproc           16385
+# End of file
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve Elasticsearch performance by disabling swapping, to avoid paging JVM heap to disk, as described in more detail (here)[https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html#mlockall]

**Which issue this PR fixes**:
fixes #8

