### PR TITLE
Updated dockerfile to use updated image and ES_VERSION reference CO-2…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 # Base image: https://github.com/pires/docker-jre
-FROM quay.io/pires/docker-jre:8u131_r2
+FROM quay.io/pires/docker-jre:8u151
+LABEL MAINTAINER="Jim Conner <snafu.x@gmail.com>"
+LABEL DESCRIPTION="Elasticsearch container for Samsung SDS"
 
 # Export HTTP & Transport
 EXPOSE 9200 9300
 
-ENV ES_VERSION 5.2.2_1
+ENV ES_VERSION 5.6.3
 
 # Install Elasticsearch.
 RUN apk add --no-cache --update elasticsearch>$ES_VERSION bash ca-certificates su-exec util-linux curl


### PR DESCRIPTION
…17 bugfix

**What this PR does / why we need it**:
Updates JRE image to latest supported and updates to latest supported elasticsearch for image (ES 5.6.3) to fix bug identified by CO-98

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # CO-217 and CO-98

